### PR TITLE
chore: add cleanup report and non-destructive removal scripts (bot/cleanup-ignored-files-2026-08-06)

### DIFF
--- a/CLEANUP_REPORT.md
+++ b/CLEANUP_REPORT.md
@@ -1,0 +1,37 @@
+# CLEANUP_REPORT.md
+
+Repository: ReSerendipity/TTS_MultiModel
+Scan date: 2026-08-06
+Large-file threshold: 5 MB
+
+Summary of findings
+
+1) Current HEAD items of note
+- personas/gf1.pt — 159,621 bytes
+- personas/旁白.pt — 51,493 bytes
+- personas/李老师.pt — 38,373 bytes
+- several other personas/*.pt in the 15 KB - 31 KB range
+
+Notes: The repository .gitignore intentionally allows personas/*.pt (there is an explicit deny-exception). Per project convention these persona files are tracked. Based on your choice A, this branch will NOT remove personas from the index. Instead this PR documents the presence of these files and provides recommendations.
+
+2) Noted directories
+- models/, pretrained_models/, outputs/, lora/ — potential locations for large weights; ensure these are ignored in .gitignore or moved to LFS/external storage.
+
+Recommendations (safe/non-destructive)
+
+A) Non-destructive review (recommended first step)
+- Keep personas tracked only if they are small, licensed for tracking, and required by consumers of the repo. Otherwise migrate large persona files to Git LFS or external storage and keep only download/install scripts in the repo.
+
+B) Historical purge (destructive — coordinate with contributors)
+- If you must remove files from history, use git filter-repo or BFG. This re-writes history and requires force push and coordination.
+
+C) Long-term strategy
+- Use Git LFS or external object storage (S3 / HF Hub) for model binaries.
+- Keep runtime artifacts (logs, outputs, uploads) out of Git; ensure .gitignore covers them.
+
+Files added in this branch
+- CLEANUP_REPORT.md (this file)
+- history_scan.sh (history scanning helper)
+- remove_tracked_sample_ttsmultimodel.sh (non-destructive removal example)
+- GITIGNORE_UPDATE.md (recommended .gitignore snippets and instructions)
+

--- a/GITIGNORE_UPDATE.md
+++ b/GITIGNORE_UPDATE.md
@@ -1,0 +1,41 @@
+GITIGNORE update recommendation for ReSerendipity/TTS_MultiModel
+
+Note: This repository intentionally allows personas/*.pt to be tracked (there is an explicit exception in .gitignore). This branch will NOT remove that exception.
+
+Suggested additions to .gitignore (append if desired):
+
+# model weights
+*.safetensors
+*.pth
+*.ckpt
+*.bin
+*.onnx
+*.gguf
+
+# outputs / audio
+outputs/
+*.wav
+*.mp3
+*.flac
+
+# runtime / logs
+logs/
+log.txt
+data/*.db
+*.db
+.env
+.env.*
+
+# virtualenv / bundled env
+WPy64-*/
+python/
+
+Instructions:
+1) To apply locally, run:
+   git checkout -b fix/update-gitignore
+   # append the snippet to .gitignore (or edit as desired)
+   git add .gitignore
+   git commit -m "chore: augment .gitignore to ignore runtime and model artifacts"
+   git push origin HEAD
+
+2) Open a PR to merge.

--- a/history_scan.sh
+++ b/history_scan.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# history_scan.sh
+# Run in a local clone of the repository to list large historical objects.
+
+OUTFILE="large_objects.txt"
+THRESHOLD_BYTES=$((5 * 1024 * 1024)) # 5 MB
+
+echo "Scanning repo history for objects larger than $THRESHOLD_BYTES bytes..."
+git rev-list --objects --all \
+  | git cat-file --batch-check='%(objectname) %(objecttype) %(objectsize) %(rest)' \
+  | awk -v thresh=$THRESHOLD_BYTES '$3 >= thresh {print $0}' \
+  | sort -k3 -n -r > "$OUTFILE"
+
+echo "Saved large objects to $OUTFILE"
+echo "To map objecthash -> paths, run:"
+echo "  git rev-list --objects --all | grep <objecthash>"
+
+git rev-list --objects --all \
+  | git cat-file --batch-check='%(objectname) %(objecttype) %(objectsize) %(rest)' \
+  | sort -k3 -n -r \
+  | head -n 200 > "top_200_objects.txt"
+echo "Top 200 objects -> top_200_objects.txt"

--- a/remove_tracked_sample_ttsmultimodel.sh
+++ b/remove_tracked_sample_ttsmultimodel.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# remove_tracked_sample_ttsmultimodel.sh
+# Per project choice A, this script will NOT automatically remove personas from the index.
+# Use the commented commands below if you decide to remove tracked persona files non-destructively.
+
+cat <<'EOF'
+# Example commands to remove specific personas from index (uncomment to use):
+# git checkout -b clean/remove-personas
+# git rm --cached personas/gf1.pt personas/旁白.pt personas/李老师.pt || true
+# echo "personas/*.pt" >> .gitignore
+# git add .gitignore
+# git commit -m "chore: remove personas .pt from index and add to .gitignore"
+# git push origin HEAD
+EOF
+
+
+echo "Per choice A, personas/*.pt are NOT removed by this branch. See CLEANUP_REPORT.md for recommendations."


### PR DESCRIPTION
# CLEANUP_REPORT.md

Repository: ReSerendipity/TTS_MultiModel
Scan date: 2026-08-06
Large-file threshold: 5 MB

Summary of findings

1) Current HEAD items of note
- personas/gf1.pt — 159,621 bytes
- personas/旁白.pt — 51,493 bytes
- personas/李老师.pt — 38,373 bytes
- several other personas/*.pt in the 15 KB - 31 KB range

Notes: The repository .gitignore intentionally allows personas/*.pt (there is an explicit deny-exception). Per project convention these persona files are tracked. Based on your choice A, this branch will NOT remove personas from the index. Instead this PR documents the presence of these files and provides recommendations.

2) Noted directories
- models/, pretrained_models/, outputs/, lora/ — potential locations for large weights; ensure these are ignored in .gitignore or moved to LFS/external storage.

Recommendations (safe/non-destructive)

A) Non-destructive review (recommended first step)
- Keep personas tracked only if they are small, licensed for tracking, and required by consumers of the repo. Otherwise migrate large persona files to Git LFS or external storage and keep only download/install scripts in the repo.

B) Historical purge (destructive — coordinate with contributors)
- If you must remove files from history, use git filter-repo or BFG. This re-writes history and requires force push and coordination.

C) Long-term strategy
- Use Git LFS or external object storage (S3 / HF Hub) for model binaries.
- Keep runtime artifacts (logs, outputs, uploads) out of Git; ensure .gitignore covers them.

Files added in this branch
- CLEANUP_REPORT.md (this file)
- history_scan.sh (history scanning helper)
- remove_tracked_sample_ttsmultimodel.sh (non-destructive removal example)
- GITIGNORE_UPDATE.md (recommended .gitignore snippets and instructions)

